### PR TITLE
Loop acceleration

### DIFF
--- a/srk/src/transition.ml
+++ b/srk/src/transition.ml
@@ -944,4 +944,105 @@ struct
       Nonlinear.linearize srk (mk_and srk (tr.guard::defs))
     in
     { transform; guard }
+
+  
+  (* Given a guarded translation and a loop counter k, compute a
+     representation of its k-fold repetition.  *)
+  let cf_translation loop_counter trans guard =
+    let cf k = (* x + k*v *)
+      M.mapi (fun var t ->
+          mk_add srk [mk_const srk (Var.symbol_of var); mk_mul srk [mk_real srk t; k]])
+        trans
+    in
+
+    (* forall subcounter. 0 <= subcounter < loop_counter ==> G(Sx + t*subcounter) *)
+    let subcounter = mk_symbol srk `TyInt in
+    let subcounter_term = mk_const srk subcounter in
+    let prestate sym = Var.of_symbol sym != None in
+    let guard = Quantifier.mbp srk prestate guard in
+    let cf_subst =
+      let sub_cf = cf subcounter_term in
+      substitute_const srk (fun sym ->
+          match Var.of_symbol sym with
+          | Some v -> (try M.find v sub_cf with Not_found -> mk_const srk sym)
+          | None -> assert false)
+    in
+    let guard_tf =
+      mk_if srk
+        (mk_and srk [mk_leq srk (mk_int srk 0) subcounter_term;
+                     mk_lt srk subcounter_term loop_counter])
+        (cf_subst guard)
+      |> mk_not srk
+      |> Quantifier.mbp srk (fun x -> x != subcounter)
+      |> mk_not srk
+    in
+    { transform = cf loop_counter; guard = guard_tf }
+
+  let try_rtc tr =
+    let solver = Smt.mk_solver srk in
+    let translation_of_model m =
+      M.fold (fun var rhs trans ->
+          M.add
+            var
+            (QQ.sub
+               (Interpretation.evaluate_term m rhs)
+               (Interpretation.real m (Var.symbol_of var)))
+            trans)
+        tr.transform
+        M.empty
+    in
+    let translation_formula trans =
+      M.fold (fun var rhs xs ->
+          (mk_eq srk
+             (mk_sub srk rhs (mk_const srk (Var.symbol_of var)))
+             (mk_real srk (M.find var trans)))
+          ::xs
+        )
+        tr.transform
+        []
+      |> mk_and srk
+    in
+    Smt.Solver.add solver [tr.guard];
+    match Smt.Solver.get_model solver with
+    | `Unknown -> None
+    | `Unsat -> Some one
+    | `Sat m ->
+      let trans1 = translation_of_model m in
+      let trans1_formula = translation_formula trans1 in
+      Smt.Solver.add solver [mk_not srk trans1_formula];
+      match Smt.Solver.get_model solver with
+      | `Unsat ->
+        let loop_counter = mk_const srk (mk_symbol srk `TyInt) in
+        Some (cf_translation loop_counter trans1 tr.guard)
+      | `Unknown -> None
+      | `Sat m2 ->
+        let trans2 = translation_of_model m2 in
+        let trans2_formula = translation_formula trans2 in
+        Smt.Solver.add solver [mk_not srk trans2_formula];
+        match Smt.Solver.check solver [] with
+        | `Sat | `Unknown -> None
+        | _ ->
+          let tr1 = { tr with guard = mk_and srk [ tr.guard; trans1_formula ] } in
+          let tr2 = { tr with guard = mk_and srk [ tr.guard; trans2_formula ] } in
+          match Smt.is_sat srk (guard (mul tr1 tr2)),
+                Smt.is_sat srk (guard (mul tr2 tr1))
+          with
+          | `Unsat, `Sat -> (* 12 UNSAT => (1+2)* = 2*1* *)
+            let loop_counter1 = mk_const srk (mk_symbol srk `TyInt) in
+            let loop_counter2 = mk_const srk (mk_symbol srk `TyInt) in
+            Some (mul
+                    (cf_translation loop_counter2 trans2 tr2.guard)
+                    (cf_translation loop_counter1 trans1 tr1.guard))
+          | `Sat, `Unsat -> (* 21 UNSAT => (1+2)* = 1*2* *)
+            let loop_counter1 = mk_const srk (mk_symbol srk `TyInt) in
+            let loop_counter2 = mk_const srk (mk_symbol srk `TyInt) in
+            Some (mul
+                    (cf_translation loop_counter1 trans1 tr1.guard)
+                    (cf_translation loop_counter2 trans2 tr2.guard))
+          | `Unsat, `Unsat ->  (* 12 & 21 UNSAT => (1+2)* = 1*+2* *)
+            let loop_counter = mk_const srk (mk_symbol srk `TyInt) in
+            Some (add
+                    (cf_translation loop_counter trans1 tr1.guard)
+                    (cf_translation loop_counter trans2 tr2.guard))
+          | _, _ -> None
 end

--- a/srk/src/transition.mli
+++ b/srk/src/transition.mli
@@ -172,4 +172,5 @@ module Make
   val domain : (module Iteration.PreDomain) ref
   val star : t -> t
   val linearize : t -> t
+  val try_rtc : t -> t option
 end

--- a/srk/src/transitionSystem.mli
+++ b/srk/src/transitionSystem.mli
@@ -35,6 +35,7 @@ module Make
        val one : t
        val star : t -> t
        val exists : (var -> bool) -> t -> t
+       val try_rtc : t -> t option
      end) : sig
 
   type vertex = int


### PR DESCRIPTION
This is a simple loop acceleration pre-processor.  It works for most of the loop-acceleration benchmarks, but not the "nested" ones.  The reason that it fails on the nested ones is because the "y" variable is not an induction variable of the outer loop.  The "TransitionSystem.remove_temporaries" pass is *almost* sufficient for side-stepping this problem (try removing the initial y=0 assignment before the outer loop) -- if we can eliminate "y" from the outer loop entirely, then we don't need it to be an induction variable.  If you implement a live variables analysis to identify temporary variables (rather than simply looking for variables that are only referenced by one transition), then we ought to be able to accelerated the nested loops as well.